### PR TITLE
Return text() instead of raw response for non-json

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -114,7 +114,7 @@ export function requestJson<T, E, B = Object>(
       if (jsonResponse) {
         return response.json()
       } else {
-        return response
+        return response.text()
       }
     })
     .then((json: T | E) => {


### PR DESCRIPTION
For non-json responses, the returned data should be the actual body of the response and not the raw response.